### PR TITLE
dark: dynamic imports fix

### DIFF
--- a/packages/vue3/src/components/Table/Internal/cells-registrar.ts
+++ b/packages/vue3/src/components/Table/Internal/cells-registrar.ts
@@ -1,19 +1,28 @@
 import type { Component } from 'vue';
-import { defineAsyncComponent } from 'vue';
 import type { TableComposableVariant } from '../types';
+import Link from './Link.vue';
+import Button from './Button.vue';
+import Thumbnail from '~/components/Thumbnail/Thumbnail.vue';
+import EditableStatus from '~/components/Status/EditableStatus.vue';
+import Percentage from '~/components/Percentage/Percentage.vue';
+import Rating from '~/components/Rating/Rating.vue';
+import Toggle from '~/components/Toggle/Toggle.vue';
+import Increment from '~/components/Increment/Increment.vue';
+import Icon from '~/components/Table/Internal/Icon.vue';
+import StaticStatus from '~/components/Status/StaticStatus.vue';
 
 export default function (name: TableComposableVariant): Component | undefined {
   switch (name) {
-    case 'thumbnail': return defineAsyncComponent(() => import('~/components/Thumbnail/Thumbnail.vue'));
-    case 'link': return defineAsyncComponent(() => import('~/components/Table/Internal/Link.vue'));
-    case 'status': return defineAsyncComponent(() => import('~/components/Status/EditableStatus.vue'));
-    case 'static-status': return defineAsyncComponent(() => import('~/components/Status/StaticStatus.vue'));
-    case 'percentage': return defineAsyncComponent(() => import('~/components/Percentage/Percentage.vue'));
-    case 'button': return defineAsyncComponent(() => import('~/components/Table/Internal/Button.vue'));
-    case 'rating': return defineAsyncComponent(() => import('~/components/Rating/RatingInput.vue'));
-    case 'toggle': return defineAsyncComponent(() => import('~/components/Toggle/Toggle.vue'));
-    case 'counter': return defineAsyncComponent(() => import('~/components/Increment/Increment.vue'));
-    case 'icon': return defineAsyncComponent(() => import('~/components/Table/Internal/Icon.vue'));
+    case 'thumbnail': return Thumbnail;
+    case 'link': return Link;
+    case 'status': return EditableStatus;
+    case 'static-status': return StaticStatus;
+    case 'percentage': return Percentage;
+    case 'button': return Button;
+    case 'rating': return Rating;
+    case 'toggle': return Toggle;
+    case 'counter': return Increment;
+    case 'icon': return Icon;
     default: return undefined;
   }
 }


### PR DESCRIPTION
## Notes

- Fixed an issue where dynamic imports caused broken `.mjs` file generation.

Removed the dynamic imports from the `cells-registrar.ts`. The only components that it "worked" for anyway were the table internals, not including the otherwise standalone components resolved as a table cell (because they were exported regardless).

> Example dist using dynamic imports
> <img width="342" alt="image" src="https://user-images.githubusercontent.com/95413644/214526758-d305a96e-6c75-47a3-a582-ac7a0f9ccc17.png">

> Error occurs during build when manifest file generation is enabled
> <img width="1325" alt="image" src="https://user-images.githubusercontent.com/95413644/214529048-280a7057-0e4a-45f2-ac36-71d34c65ae13.png">

The following is the `manifest.json` generated when using dynamic imports, notice how there is no default `.umd` export.
```json
{
  "src/index.ts": {
    "file": "index.es.js",
    "src": "src/index.ts",
    "isEntry": true,
    "imports": [
      "_index-10d5663a.mjs"
    ]
  },
  "index.css": {
    "file": "index.css",
    "src": "index.css"
  },
  "src/components/Table/Internal/Button.vue": {
    "file": "Button-e7ee7df4.mjs",
    "src": "src/components/Table/Internal/Button.vue",
    "isDynamicEntry": true,
    "imports": [
      "_index-10d5663a.mjs"
    ]
  },
  "src/components/Table/Internal/Link.vue": {
    "file": "Link-125b2570.mjs",
    "src": "src/components/Table/Internal/Link.vue",
    "isDynamicEntry": true
  },
  "src/components/Table/Internal/Icon.vue": {
    "file": "Icon-097a357e.mjs",
    "src": "src/components/Table/Internal/Icon.vue",
    "isDynamicEntry": true
  },
  "_index-10d5663a.mjs": {
    "file": "index-10d5663a.mjs",
    "dynamicImports": [
      "src/components/Table/Internal/Link.vue",
      "src/components/Table/Internal/Button.vue",
      "src/components/Table/Internal/Icon.vue"
    ],
    "css": [
      "index.css"
    ]
  }
}
```

The following is the generated `Icon-*.mjs` containing an import statement that breaks when the package is used in the theme-editor.
```js
import { defineComponent as o, openBlock as n, createElementBlock as c, normalizeClass as _ } from "vue";
import { _ as t } from "./index-ea9122df.mjs";
const s = /* @__PURE__ */ o({
  __name: "Icon",
  props: {
    iconName: null
  },
  setup(e) {
    return (a, l) => (n(), c("i", {
      class: _(["icon", e.iconName])
    }, null, 2));
  }
});
const m = /* @__PURE__ */ t(s, [["__scopeId", "data-v-672e6715"]]);
export {
  m as default
};
```


