### PR TITLE
DARK: Fix tablerow actions not sending tabledata on click

### DIFF
--- a/packages/vue3/src/_dev/App.vue
+++ b/packages/vue3/src/_dev/App.vue
@@ -26,8 +26,8 @@ const data = ref<TableData[]>(
             // iconName: 'i-youcan-x',
           },
           events: {
-            click: () => {
-              console.log('click');
+            click: (x) => {
+              console.log('click', x);
             },
           },
         },
@@ -118,8 +118,8 @@ const actions: TableActions[] = [
     label: 'Delete',
     iconName: 'i-youcan-trash',
     events: {
-      click: () => {
-        console.log('delete');
+      click: (x) => {
+        console.log('delete', x);
       },
     },
   },

--- a/packages/vue3/src/components/Table/types.ts
+++ b/packages/vue3/src/components/Table/types.ts
@@ -24,7 +24,7 @@ export interface TableActions {
   iconName?: string
   criteria?: (value: TableData) => boolean
   events?: {
-    click: (row: TableData, index: number) => void
+    click: (row: TableDataRow, index?: number) => void
   }
 }
 


### PR DESCRIPTION
## Notes

Before this change, when creating an action for table, clicking on that action didn't sent `TableData`, rather, sent nothing but the click event.

This PR aims to fix that.

## QA Steps

- Run the dev env
- Go to `localhost:3001`
- Click on the trash icon for row
- Check console, you should see that row data displayed.