### PR TITLE
YSHOP2-121: Alert component adjustements

### DIFF
--- a/packages/vue3/src/_dev/App.vue
+++ b/packages/vue3/src/_dev/App.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import 'uno.css';
 import '../assets/main.css';
-import { ref } from 'vue';
-import RadioList from '~/components/RadioList/RadioList.vue';
-import type { RadioListOption } from '~/components/RadioList/types';
-
-const options = [
-  { label: 'DHL Express - Morocco', suffix: '35 MAD' },
-  { label: 'Amana Eco - Morocco', suffix: '40 MAD' },
-];
-
-const selected = ref<RadioListOption>();
+import Alert from '~/components/Alert/Alert.vue';
 </script>
 
 <template>
   <div>
     <div class="container">
-      <h3>Selected: {{ selected || 'nothing' }}</h3>
-      <RadioList v-model="selected" :options="options" />
+      <h3>Alert component</h3>
+      <Alert type="info">
+        <template #title>
+          hello
+        </template>
+      </Alert>
     </div>
   </div>
 </template>

--- a/packages/vue3/src/components/Alert/Alert.vue
+++ b/packages/vue3/src/components/Alert/Alert.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useSlots } from 'vue';
 import type { AlertType } from './types';
 import TertiaryButton from '~/components/Button/TertiaryButton.vue';
 
@@ -17,6 +18,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'close'): void
 }>();
+const { title, description } = useSlots();
 
 const handleClose = () => {
   emit('close');
@@ -42,15 +44,11 @@ if (props.closeAfterDuration && typeof props.closeAfterDuration === 'number') {
         />
       </div>
       <div class="content-container">
-        <span class="title" :class="[type]">
-          <slot name="title">
-            Example: Short toast title
-          </slot>
+        <span v-if="title" class="title" :class="[type]">
+          <slot name="title" />
         </span>
-        <span class="description" :class="[type]">
-          <slot name="description">
-            Example: Short description using toast.
-          </slot>
+        <span v-if="description" class="description" :class="[type]">
+          <slot name="description" />
         </span>
       </div>
       <!-- Close button -->
@@ -71,7 +69,7 @@ if (props.closeAfterDuration && typeof props.closeAfterDuration === 'number') {
 
   display: flex;
   position: relative;
-  width: 496px;
+  width: 100%;
   margin-bottom: 12px;
   padding: 12px;
   border: 1px solid var(--gray-200);


### PR DESCRIPTION
## JIRA Ticket
[YSHOP2-121](https://youcanshop.atlassian.net/browse/YSHOP2-121)

The alert component needs to be adjusted to be used inside the Create Order section.
Fixes:

The alert must take full width of it’s parent container

The when a slot is not used it should not be displayed

<img width="946" alt="Screen Shot 2023-03-02 at 12 20 19" src="https://user-images.githubusercontent.com/117163420/222414471-3cf5b96f-c141-4a4e-9c54-2763eaf152bf.png">

## QA Steps

* [ ] run `pnpm i`
* [ ] visit `localhost:3000`

## Note

Leave empty when you have nothing to say


[YSHOP2-121]: https://youcanshop.atlassian.net/browse/YSHOP2-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ