### PR TITLE
Dark: Fix Datepicker when being used inside a form

### DIFF
--- a/packages/vue3/src/components/Button/_BaseButton.vue
+++ b/packages/vue3/src/components/Button/_BaseButton.vue
@@ -13,7 +13,7 @@ withDefaults(
     size: 'md',
     iconPosition: 'left',
     roundedFull: false,
-    disabled: false
+    disabled: false,
   },
 );
 


### PR DESCRIPTION
## JIRA Ticket

When we used a date picker inside a form, we noticed an unexpected behavior which is when you click on the buttons that trigger changing the month, the form gets submitted since those buttons don't have a type, by default if a button doesn't have a type of button inside a form it will submit the content of the form 

**Steps to reproduce:**
- use a date picker inside a form
- try to change the month via the buttons 
- the form will be submitted 

## QA Steps

* [ ] Try to use the date picker inside a form then switch the month via the TertiaryButtons 

## Note

Leave empty when you have nothing to say
