### PR TITLE
DARK: improve collapse/expand icon state in Sidebar

### DIFF
--- a/packages/vue3/src/_dev/App.vue
+++ b/packages/vue3/src/_dev/App.vue
@@ -2,133 +2,63 @@
 import 'uno.css';
 import '~/assets/main.css';
 import { ref } from 'vue';
-import { PrimaryButton, ResourcePicker } from '~/components';
-import type { Resource } from '~/components/ResourcePicker/types';
-
-const MOCK_RESOURCES: Resource[] = [
+import { Sidebar, SidebarItem, SidebarSubitem } from '~/components';
+const items = [
   {
-    id: 1,
-    thumbnailUrl: '',
-    name: 'Apple MacBook Pro',
-    price: '$10.99',
-    stock: 99,
-    isChecked: false,
-    variants: [
-      {
-        id: 33,
-        thumbnailUrl: '',
-        name: 'Apple MacBook Pro 16 M3 Max',
-        price: '$10.99',
-        stock: 99,
-        isChecked: false,
-      },
-      {
-        id: 21,
-        thumbnailUrl: '',
-        name: 'Apple MacBook Pro 14 M3 Pro',
-        price: '$10.99',
-        stock: 99,
-        isChecked: false,
-      },
+    label: 'Products',
+    active: true,
+    icon: 'i-youcan-tag',
+    children: [
+      { label: 'All Products' },
+      { label: 'Categories' },
     ],
   },
   {
-    id: 2,
-    thumbnailUrl: '',
-    name: 'Apple iMac',
-    price: '$10.99',
-    stock: 99,
-    isChecked: false,
-  },
-  {
-    id: 3,
-    thumbnailUrl: '',
-    name: 'Apple Watch',
-    price: '$10.99',
-    stock: 99,
-    isChecked: false,
+    label: 'Insights',
+    active: false,
+    icon: 'i-youcan-chart-line',
   },
 ];
-
-const showPicker = ref(false);
-const showLoadingPicker = ref(false);
-const showEmptyPicker = ref(false);
-const selectedResources = ref<Resource[]>([]);
-
-const onConfirm = (resources: Resource[]) => {
-  selectedResources.value = resources;
-  showPicker.value = false;
-};
-
-const onSearch = (term: string) => {
-  console.log('Search term:', term);
+const localStorageKey = 'sidebar-collapsed';
+const isCollapsed = localStorage.getItem(localStorageKey) === 'true';
+const sideBarCollapsed = ref(isCollapsed);
+const handleCollapse = (collapsed: boolean) => {
+  sideBarCollapsed.value = collapsed;
+  localStorage.setItem(localStorageKey, String(collapsed));
 };
 </script>
 
 <template>
   <div class="container">
-    <div class="picker">
-      <ResourcePicker
-        v-model:visible="showPicker"
-        :resources="MOCK_RESOURCES"
-        stock-label="in stock"
-        :is-loading="false"
-        @confirm="onConfirm"
-        @search="onSearch"
-      />
-      <PrimaryButton @click="showPicker = true;">
-        <span>Open Picker</span>
-      </PrimaryButton>
-    </div>
-    <div class="picker">
-      <ResourcePicker
-        v-model:visible="showLoadingPicker"
-        :is-loading="true"
-      />
-      <PrimaryButton @click="showLoadingPicker = true;">
-        <span>Open Loading Picker</span>
-      </PrimaryButton>
-    </div>
-    <div class="picker">
-      <ResourcePicker
-        v-model:visible="showEmptyPicker"
-        :resources="[]"
-        :is-loading="false"
-      />
-      <PrimaryButton @click="showEmptyPicker = true;">
-        <span>Open Empty Picker</span>
-      </PrimaryButton>
-    </div>
-    <div class="selection-container">
-      <p>Selected Resources:</p>
-      <pre>{{ selectedResources }}</pre>
-    </div>
+    <Sidebar :collapsed="sideBarCollapsed" @collapse="handleCollapse">
+      <template #header>
+        <p>Awesome App</p>
+      </template>
+      <template #items>
+        <SidebarItem
+          v-for="item in items"
+          :key="item.label"
+          :label="item.label"
+          :active="item.active"
+          :icon="item.icon"
+        >
+          <template v-if="item.children">
+            <SidebarSubitem
+              v-for="subItem in item.children" :key="subItem.label"
+              :label="subItem.label"
+            />
+          </template>
+        </SidebarItem>
+      </template>
+      <template #lower-items>
+        <SidebarItem icon="i-youcan-gear" label="Settings" />
+      </template>
+    </Sidebar>
   </div>
 </template>
 
 <style scoped>
 .container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  width: 100vw;
-  min-height: 100vh;
-  margin: 0 auto;
-  padding: 32px 0;
-  /* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
-  font-family: "Mona Sans";
-  gap: 32px;
-}
-
-.selection-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-width: 400px;
-  padding: 32px;
-  border: 1px solid var(--gray-200);
-  border-radius: 8px;
+  /* direction: rtl; */
 }
 </style>

--- a/packages/vue3/src/components/Sidebar/Sidebar.vue
+++ b/packages/vue3/src/components/Sidebar/Sidebar.vue
@@ -21,7 +21,7 @@ const toggle = (override = !collapsed.value) => {
   <aside class="sidebar" :class="{ collapsed }">
     <div class="sidebar-header">
       <button class="item-icon" @click="() => toggle()">
-        <i class="i-youcan:arrow-line-down" />
+        <i class="i-youcan:list" />
       </button>
       <div class="item-label">
         <slot name="header" />
@@ -53,7 +53,7 @@ const toggle = (override = !collapsed.value) => {
   background-color: var(--gray-800);
 
   i {
-    color: var(--gray-400);
+    color: var(--gray-200);
   }
 
   &-header {
@@ -80,7 +80,6 @@ const toggle = (override = !collapsed.value) => {
       cursor: pointer;
 
       i {
-        transform: rotate(-90deg);
         transition: transform 0.25s ease-in-out;
       }
     }
@@ -174,7 +173,7 @@ const toggle = (override = !collapsed.value) => {
     .sidebar-header {
       .item-icon {
         i {
-          transform: rotate(90deg);
+          color: var(--gray-500);
         }
       }
     }
@@ -185,14 +184,6 @@ const toggle = (override = !collapsed.value) => {
 <style lang="scss">
 html[dir="rtl"] {
   .sidebar {
-    .sidebar-header {
-      .item-icon {
-        i {
-          transform: rotate(90deg);
-        }
-      }
-    }
-
     &.collapsed {
       .item-label,
       .subitem-text {
@@ -204,14 +195,6 @@ html[dir="rtl"] {
           right: 25px;
           left: unset;
           transform: translateX(50%);
-        }
-      }
-
-      .sidebar-header {
-        .item-icon {
-          i {
-            transform: rotate(-90deg);
-          }
         }
       }
     }


### PR DESCRIPTION
## JIRA Ticket

## QA Steps

* [ ] Go to `localhost:3000`
* [ ] If the sidebar is expanded the burger menu icon should be bright
* [ ] If the sidebar is collapsed the burger menu icon should be dimmed

## Note

Leave empty when you have nothing to say
