### PR TITLE
DARK: add check to disable add button if no resources are selected

### DIFF
--- a/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
+++ b/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
@@ -30,10 +30,12 @@ const shouldDisabledAddButton = computed(() => {
 });
 
 const closePicker = () => {
+  term.value = '';
   emit('update:visible', false);
 };
 
 const handleAdd = () => {
+  term.value = '';
   const selectedResourcesWithVariants = selectedResources.value?.map((resource) => {
     if (resource.variants) {
       return {

--- a/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
+++ b/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
@@ -25,7 +25,7 @@ const selectedResources = computed(() => {
   return selectedResources;
 });
 
-const canAddResources = computed(() => {
+const shouldDisabledAddButton = computed(() => {
   return props.isLoading || isEmptyArray(props.resources) || isEmptyArray(selectedResources.value);
 });
 
@@ -150,7 +150,7 @@ onUnmounted(() => {
             <SecondaryButton @click="closePicker">
               <span>{{ cancelLabel }}</span>
             </SecondaryButton>
-            <PrimaryButton :disabled="canAddResources" @click="handleAdd">
+            <PrimaryButton :disabled="shouldDisabledAddButton" @click="handleAdd">
               <span>{{ confirmLabel }}</span>
             </PrimaryButton>
           </div>

--- a/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
+++ b/packages/vue3/src/components/ResourcePicker/ResourcePicker.vue
@@ -25,6 +25,10 @@ const selectedResources = computed(() => {
   return selectedResources;
 });
 
+const canAddResources = computed(() => {
+  return props.isLoading || isEmptyArray(props.resources) || isEmptyArray(selectedResources.value);
+});
+
 const closePicker = () => {
   emit('update:visible', false);
 };
@@ -146,7 +150,7 @@ onUnmounted(() => {
             <SecondaryButton @click="closePicker">
               <span>{{ cancelLabel }}</span>
             </SecondaryButton>
-            <PrimaryButton :disabled="isLoading || isEmptyArray(resources)" @click="handleAdd">
+            <PrimaryButton :disabled="canAddResources" @click="handleAdd">
               <span>{{ confirmLabel }}</span>
             </PrimaryButton>
           </div>


### PR DESCRIPTION
## QA Steps

### Fix #1
* [x] Go to `http://localhost:3000/`
* [ ] Click on "Open Picker" button
* [ ] The add button inside of the picker should be disabled until you start selecting at least 1 resource
### Fix #2
* [ ] Go to `http://localhost:3000/`
* [ ] Click on "Open Picker" button
* [ ] Type something in the search box in the picker
* [ ] Close the picker
* [ ] Open the picker again, the input should be cleared