### PR TITLE
UI-506: ui-vue3 > Add ability to clear date picker

### DIFF
--- a/packages/vue3/src/_dev/App.vue
+++ b/packages/vue3/src/_dev/App.vue
@@ -1,48 +1,15 @@
 <script setup lang="ts">
 import 'uno.css';
 import '../assets/main.css';
-import { Alert } from '~/components';
-import type { AlertType } from '~/types';
+import { ref } from 'vue';
+import SingleDateInput from '~/components/DateInput/SingleDateInput.vue';
 
-interface AlertProps {
-  title: string
-  description: string
-  type: AlertType
-}
-const alerts: AlertProps[] = [
-  {
-    title: 'Info',
-    description: 'Click here to learn more about the exciting enhancements we\'ve made.',
-    type: 'info',
-  },
-  {
-    title: 'Success',
-    description: 'Your profile information has been successfully updated.',
-    type: 'success',
-  },
-  {
-    title: 'Warning',
-    description: 'Please check your internet connection.',
-    type: 'warning',
-  },
-  {
-    title: 'Error',
-    description: 'Unable to save data, check again later.',
-    type: 'error',
-  },
-];
+const date = ref();
 </script>
 
 <template>
   <div class="container">
-    <Alert v-for="alert in alerts" :key="alert.type" :type="alert.type">
-      <template #title>
-        {{ alert.title }}
-      </template>
-      <template #description>
-        {{ alert.description }}
-      </template>
-    </Alert>
+    <SingleDateInput v-model="date" />
   </div>
 </template>
 

--- a/packages/vue3/src/components/DateInput/DateInput.vue
+++ b/packages/vue3/src/components/DateInput/DateInput.vue
@@ -26,6 +26,11 @@ const toggleDatePicker = (state = !isDatePickerVisible.value) => {
 };
 
 onClickOutside(datePicker, () => toggleDatePicker(false));
+
+function clearModelValue(e: Event) {
+  e.stopPropagation();
+  emit('update:modelValue', { start: null, end: null });
+}
 </script>
 
 <template>
@@ -39,6 +44,9 @@ onClickOutside(datePicker, () => toggleDatePicker(false));
       </span>
       <span v-show="!model.start && !model.start" class="placeholder">{{ placeholder }}</span>
       <template #icon>
+        <TertiaryButton v-if="model.start || model.end" class="clear-button" @click="clearModelValue">
+          <i class="i-youcan:x" />
+        </TertiaryButton>
         <i class="i-youcan-calendar-blank" />
       </template>
     </SecondaryButton>
@@ -75,5 +83,13 @@ onClickOutside(datePicker, () => toggleDatePicker(false));
 .date-input .date-picker-container .date-picker {
   position: absolute;
   top: 8px;
+}
+
+.date-input .clear-button {
+  padding: 0 8px;
+}
+
+.date-input .clear-button i {
+  background-color: var(--gray-400);
 }
 </style>

--- a/packages/vue3/src/components/DateInput/SingleDateInput.vue
+++ b/packages/vue3/src/components/DateInput/SingleDateInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-// import type { Ref } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { computed, ref } from 'vue';
+import TertiaryButton from '../Button/TertiaryButton.vue';
 import type { SingleDateInputProps } from './types';
 import { SecondaryButton, SingleDatePicker } from '~/components';
 
@@ -22,13 +22,18 @@ const toggleDatePicker = (state = !isDatePickerVisible.value) => {
 
 const model = computed({
   get: () => props.modelValue,
-  set: (value: Date | null) => {
+  set: (value?: Date) => {
     toggleDatePicker(false);
     emit('update:modelValue', value);
   },
 });
 
 onClickOutside(datePicker, () => toggleDatePicker(false));
+
+function clearModelValue(e: Event) {
+  e.stopPropagation();
+  emit('update:modelValue', null);
+}
 </script>
 
 <template>
@@ -41,7 +46,11 @@ onClickOutside(datePicker, () => toggleDatePicker(false));
         {{ model?.toLocaleDateString() }}
       </span>
       <span v-show="!model" class="placeholder">{{ placeholder }}</span>
+      <div class="accessory" />
       <template #icon>
+        <TertiaryButton v-if="modelValue" class="clear-button" @click="clearModelValue">
+          <i class="i-youcan:x" />
+        </TertiaryButton>
         <i class="i-youcan-calendar-blank" />
       </template>
     </SecondaryButton>
@@ -78,5 +87,13 @@ onClickOutside(datePicker, () => toggleDatePicker(false));
 .date-input .date-picker-container .date-picker {
   position: absolute;
   top: 8px;
+}
+
+.date-input .clear-button {
+  padding: 0 8px;
+}
+
+.date-input .clear-button i {
+  background-color: var(--gray-400);
 }
 </style>

--- a/packages/vue3/src/components/DateInput/types.ts
+++ b/packages/vue3/src/components/DateInput/types.ts
@@ -14,11 +14,11 @@ export interface DatePickerProps {
 }
 
 export interface SingleDatePickerProps {
-  modelValue: Date
+  modelValue?: Date
 }
 
 export interface SingleDateInputProps {
-  modelValue: Date
+  modelValue?: Date
   disabled?: boolean
   placeholder?: string
 }


### PR DESCRIPTION
## JIRA Ticket

[UI-506](https://youcanshop.atlassian.net/browse/UI-506)

## QA Steps
> [!Note]
>
> The github actions below are for alto, this PR introduces a fix in ui-vue3 :sadge: so you'd have to QA it manually

- [ ] cd into `packages/vue3`
- [ ] run `pnpm dev`
- [ ] a browser window should open and you should see storybook
- [ ] look for Date / Single and Date / Range
- [ ] test them both out by specifying a date, when you do you should notice an "X" button next to the calendar icon
- [ ] Click on the "X" button
- [ ] The date value should be cleared

https://github.com/user-attachments/assets/383b668a-cb45-4e67-a51a-3b420054d2a7


https://github.com/user-attachments/assets/f437968c-8495-49a2-a30a-155ebe53ed4c


## Note

Leave empty when you have nothing to say


[UI-506]: https://youcanshop.atlassian.net/browse/UI-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ